### PR TITLE
Build with warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.17)
 
 project(tabetai2)
 
+add_subdirectory(warning)
+
 add_subdirectory(core/database)
 add_subdirectory(core/ingredient)
 add_subdirectory(core/server)

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(${PROJECT_NAME}
         ingredient
         server
         database
+        warning
 )

--- a/core/database/CMakeLists.txt
+++ b/core/database/CMakeLists.txt
@@ -14,6 +14,11 @@ target_include_directories(${PROJECT_NAME}
         include
 )
 
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        warning
+)
+
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
         LINKER_LANGUAGE CXX

--- a/core/ingredient/CMakeLists.txt
+++ b/core/ingredient/CMakeLists.txt
@@ -21,4 +21,6 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
         database
+    PRIVATE
+        warning
 )

--- a/core/ingredient/src/ingredient_repository.cpp
+++ b/core/ingredient/src/ingredient_repository.cpp
@@ -18,6 +18,7 @@ void IngredientRepository::erase(const Ingredient& ingredient) {
 }
 
 std::optional<Ingredient> IngredientRepository::find_by_id(int id) {
+    (void)id;
     // TODO fix this shit
 //    return m_database->get(id);
     return {};

--- a/core/server/CMakeLists.txt
+++ b/core/server/CMakeLists.txt
@@ -24,4 +24,5 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
         ingredient
+        warning
 )

--- a/core/server/include/server/server.h
+++ b/core/server/include/server/server.h
@@ -8,6 +8,7 @@ namespace tabetai2::core::server {
 
 class Server {
 public:
+    virtual ~Server() = default;
     virtual void run() = 0;
 };
 

--- a/core/server/include/server/server_factory.h
+++ b/core/server/include/server/server_factory.h
@@ -8,6 +8,7 @@ namespace tabetai2::core::server {
 
 class ServerFactory {
 public:
+    virtual ~ServerFactory() = default;
     virtual std::unique_ptr<Server> create() = 0;
 };
 

--- a/warning/CMakeLists.txt
+++ b/warning/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(warning)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_compile_options(${PROJECT_NAME} INTERFACE
+    $<$<CXX_COMPILER_ID:Clang,GNU>:
+        -Wall;
+        -Wcast-align;
+        -Wdouble-promotion;
+        -Werror;
+        -Wextra;
+        -Wformat=2;
+        -Wmissing-declarations;
+        -Wnon-virtual-dtor;
+        -Wnull-dereference;
+        -Wold-style-cast;
+        -Woverloaded-virtual;
+        -Wshadow;
+        -Wundef;
+    >
+    $<$<CXX_COMPILER_ID:MSVC>:
+        /permissive-;
+        /W4;
+        /WX;
+    >
+)


### PR DESCRIPTION
* Added a CMake target for propagating warnings around.
* Added missing virtual destructors.
* Explicitly marked unused arguments as unused.