### PR TITLE
Fix build for MSVC

### DIFF
--- a/core/ingredient/include/ingredient/ingredient_repository.h
+++ b/core/ingredient/include/ingredient/ingredient_repository.h
@@ -5,6 +5,7 @@
 #include "ingredient.h"
 
 #include <memory>
+#include <optional>
 
 namespace tabetai2::core::ingredient {
 


### PR DESCRIPTION
Apparently MSVC has a cleaner stdlib than both Clang and gcc. Who
would've guessed?