### PR TITLE
Don't force linking of header-only libraries

### DIFF
--- a/core/database/CMakeLists.txt
+++ b/core/database/CMakeLists.txt
@@ -1,25 +1,18 @@
 project(database)
 
-add_library(${PROJECT_NAME}
-    include/database/database.hpp
-)
+add_library(${PROJECT_NAME} INTERFACE)
 
 target_compile_features(${PROJECT_NAME}
-    PRIVATE
+    INTERFACE
         cxx_std_20
 )
 
 target_include_directories(${PROJECT_NAME}
-    PUBLIC
+    INTERFACE
         include
 )
 
 target_link_libraries(${PROJECT_NAME}
-    PRIVATE
+    INTERFACE
         warning
-)
-
-set_target_properties(${PROJECT_NAME}
-    PROPERTIES
-        LINKER_LANGUAGE CXX
 )

--- a/core/server/CMakeLists.txt
+++ b/core/server/CMakeLists.txt
@@ -6,11 +6,6 @@ add_library(${PROJECT_NAME}
     src/server.cpp
 )
 
-set_target_properties(${PROJECT_NAME}
-    PROPERTIES
-        LINKER_LANGUAGE CXX
-)
-
 target_compile_features(${PROJECT_NAME}
     PRIVATE
         cxx_std_20


### PR DESCRIPTION
This means changing them from being a regular library to being an
INTERFACE library. A drawback of this is that files can't be specified
in the add_library-call, but oh well, probably worth it to not link
things that don't need linking?