### PR TITLE
Use constructor inheritance to pull in identical constructor

### DIFF
--- a/core/ingredient/include/ingredient/ingredient_repository.h
+++ b/core/ingredient/include/ingredient/ingredient_repository.h
@@ -12,7 +12,7 @@ namespace tabetai2::core::ingredient {
 
 class IngredientRepository : public repository::Repository<Ingredient> {
 public:
-    explicit IngredientRepository(std::unique_ptr<database::Database<Ingredient>> database);
+    using Repository<Ingredient>::Repository;
 
     std::optional<Ingredient> find_by_id(int id) const;
     std::optional<Ingredient> find_by_name(const std::string& name) const;

--- a/core/ingredient/src/ingredient_repository.cpp
+++ b/core/ingredient/src/ingredient_repository.cpp
@@ -2,13 +2,6 @@
 
 namespace tabetai2::core::ingredient {
 
-using namespace database;
-
-IngredientRepository::IngredientRepository(std::unique_ptr<Database<Ingredient>> database)
-: Repository(std::move(database)) {
-
-}
-
 std::optional<Ingredient> IngredientRepository::find_by_id(int id) const {
     return m_database->get(id);
 }


### PR DESCRIPTION
If the constructor only forwards its arguments to the base class, you're allowed to pull it in w/ a using declaration.