### PR TITLE
Fix VC++ compilation

### DIFF
--- a/core/server/src/server_factory.cpp
+++ b/core/server/src/server_factory.cpp
@@ -11,7 +11,6 @@ using namespace core::database;
 using namespace core::data_publisher;
 using namespace core::ingredient;
 using namespace core::repository;
-using namespace core::server;
 using namespace core::util;
 
 ServerFactory::ServerFactory(std::unique_ptr<RepositoryPublisherFactory> repository_publisher_factory)


### PR DESCRIPTION
Using `using namespace core::server` inside the `core::server` namespace
is a warning in VC++ and we build with warnings-as-errors.

(Also it's pretty weird to use `using namespace core::server` when you're already in `core::server` 🐍)