### PR TITLE
Add Linux gcc/clang CI using GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,50 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CTEST_OUTPUT_ON_FAILURE: ON
+      CTEST_PARALLEL_LEVEL: 2
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-18.04-gcc-9
+            os: ubuntu-18.04
+            compiler: gcc
+            version: "9"
+
+          - name: ubuntu-18.04-clang-9
+            os: ubuntu-18.04
+            compiler: clang
+            version: "9"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install
+        run: |
+          python -m pip install cmake==3.17.3 conan==1.28.1 --upgrade
+          conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan --force
+          sudo apt update
+          if [ "${{ matrix.compiler }}" = "gcc" ]; then
+            sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
+            echo "::set-env name=CC::gcc-${{ matrix.version }}"
+            echo "::set-env name=CXX::g++-${{ matrix.version }}"
+          else
+            sudo apt-get install -y clang-${{ matrix.version }} g++-multilib
+            echo "::set-env name=CC::clang-${{ matrix.version }}"
+            echo "::set-env name=CXX::clang++-${{ matrix.version }}"
+          fi
+      - name: Build
+        run: |
+          cmake -S . -B build ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Debug -DTABETAI2_USE_CONAN=TRUE
+          cmake --build build --config Debug

--- a/third_party/autobahn_cpp/CMakeLists.txt
+++ b/third_party/autobahn_cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ FetchContent_GetProperties(msgpack-c
     SOURCE_DIR msgpack-c_SOURCE_DIR
 )
 set(MSGPACK_ROOT "${msgpack-c_SOURCE_DIR}")
+set(AUTOBAHN_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
     autobahn


### PR DESCRIPTION
Based on #8 

I had to disable the autobahn-cpp example compilation as they were missing boost/asio even though the rest of autobahn-cpp built fine w/ lots of boost/asio includes.