### PR TITLE
Fix cross-compiling to Windows

### DIFF
--- a/third_party/autobahn_cpp/CMakeLists.txt
+++ b/third_party/autobahn_cpp/CMakeLists.txt
@@ -22,3 +22,8 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(autobahn_cpp)
+
+target_link_libraries(autobahn_cpp
+    INTERFACE
+        $<$<BOOL:${WIN32}>:ws2_32>
+)

--- a/wamp_publisher/include/wamp_publisher/session.h
+++ b/wamp_publisher/include/wamp_publisher/session.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <autobahn/wamp_session.hpp>
+#include <autobahn/autobahn.hpp>
 
 #include <memory>
 


### PR DESCRIPTION
Including anything but <autobahn/autobahn.hpp> when including their
headers can lead to defines missing the first time a header is included
which leads to issues.

autobahn_cpp also pulls in boost/asio which needs to link against
ws2_32, so I added that link-dependency to their target.