### PR TITLE
Repo publisher explosion

### DIFF
--- a/core/data_publisher/CMakeLists.txt
+++ b/core/data_publisher/CMakeLists.txt
@@ -19,3 +19,5 @@ target_link_libraries(${PROJECT_NAME}
         repository
         util
 )
+
+add_subdirectory(test)

--- a/core/data_publisher/include/data_publisher/repository_publisher.hpp
+++ b/core/data_publisher/include/data_publisher/repository_publisher.hpp
@@ -12,11 +12,18 @@ namespace tabetai2::core::data_publisher {
 template<class T>
 class RepositoryPublisher : public Publisher, public util::Observer {
 public:
-    explicit RepositoryPublisher(const std::shared_ptr<repository::Repository<T>>& repository) {
-        repository->add_observer(this);
+    explicit RepositoryPublisher(const std::shared_ptr<repository::Repository<T>> &repository) :
+            m_repository(repository) {
+        m_repository->add_observer(this);
+    }
+
+    ~RepositoryPublisher() {
+        m_repository->remove_observer(this);
     }
 
 private:
+    std::shared_ptr<repository::Repository<T>> m_repository;
+
     void notify() override {
         publish();
     }

--- a/core/data_publisher/test/CMakeLists.txt
+++ b/core/data_publisher/test/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(test_data_publisher)
+
+include(Catch)
+
+add_executable(${PROJECT_NAME}
+    src/main.cpp
+    src/test_repository_publisher.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        data_publisher
+        # TODO(robinlinden): Mocking a repository would be cleaner, but we
+        # already get this dependency from data_publisher.
+        ingredient
+        Catch2::Catch2
+)
+
+target_compile_features(${PROJECT_NAME}
+    PRIVATE
+        cxx_std_20
+)
+
+catch_discover_tests(${PROJECT_NAME})

--- a/core/data_publisher/test/src/main.cpp
+++ b/core/data_publisher/test/src/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/core/data_publisher/test/src/test_repository_publisher.cpp
+++ b/core/data_publisher/test/src/test_repository_publisher.cpp
@@ -1,0 +1,28 @@
+#include "data_publisher/repository_publisher.hpp"
+
+#include "database/in_memory_database.hpp"
+#include "ingredient/ingredient_repository.h"
+
+#include <catch2/catch.hpp>
+
+using namespace tabetai2::core::data_publisher;
+using namespace tabetai2::core::database;
+using namespace tabetai2::core::ingredient;
+
+namespace {
+
+struct TestRepoPublisher : RepositoryPublisher<Ingredient> {
+    using RepositoryPublisher<Ingredient>::RepositoryPublisher;
+    void publish() override {}
+};
+
+TEST_CASE("RepositoryPublisher") {
+    auto repository = std::make_shared<IngredientRepository>(std::make_unique<InMemoryDatabase<Ingredient>>());
+
+    SECTION("Cleans up after itself") {
+        (void)TestRepoPublisher(repository);
+        repository->add({0, "fish"});
+    }
+}
+
+}

--- a/core/util/include/util/impl/observable.h
+++ b/core/util/include/util/impl/observable.h
@@ -10,6 +10,7 @@ namespace tabetai2::core::util::impl {
 class Observable : public util::Observable {
 public:
     void add_observer(util::Observer* observer);
+    void remove_observer(const util::Observer* observer);
 
 protected:
     void notify_observers() override;

--- a/core/util/src/observable.cpp
+++ b/core/util/src/observable.cpp
@@ -6,6 +6,10 @@ void Observable::add_observer(util::Observer* const observer) {
     m_observers.push_back(observer);
 }
 
+void Observable::remove_observer(const util::Observer* const observer) {
+    std::erase(m_observers, observer);
+}
+
 void Observable::notify_observers() {
     for (auto observer : m_observers) {
         observer->notify();


### PR DESCRIPTION
`std::erase(container, item)` is new in C++20 and replaces the erase-remove idiom. 😨 