### PR TITLE
Disallow usage of GNU extensions

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -9,6 +9,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
         database

--- a/core/data_publisher/test/CMakeLists.txt
+++ b/core/data_publisher/test/CMakeLists.txt
@@ -21,4 +21,11 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 catch_discover_tests(${PROJECT_NAME})

--- a/core/database/CMakeLists.txt
+++ b/core/database/CMakeLists.txt
@@ -18,6 +18,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         include

--- a/core/ingredient/CMakeLists.txt
+++ b/core/ingredient/CMakeLists.txt
@@ -14,6 +14,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         include

--- a/core/recipe/CMakeLists.txt
+++ b/core/recipe/CMakeLists.txt
@@ -18,6 +18,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         include

--- a/core/recipe/test/CMakeLists.txt
+++ b/core/recipe/test/CMakeLists.txt
@@ -18,4 +18,11 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 catch_discover_tests(${PROJECT_NAME})

--- a/core/server/CMakeLists.txt
+++ b/core/server/CMakeLists.txt
@@ -13,6 +13,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         include

--- a/core/util/CMakeLists.txt
+++ b/core/util/CMakeLists.txt
@@ -13,6 +13,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         include

--- a/wamp/wamp_publisher/CMakeLists.txt
+++ b/wamp/wamp_publisher/CMakeLists.txt
@@ -15,6 +15,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         include

--- a/wamp/wamp_session/CMakeLists.txt
+++ b/wamp/wamp_session/CMakeLists.txt
@@ -14,6 +14,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         include

--- a/yaml_database/CMakeLists.txt
+++ b/yaml_database/CMakeLists.txt
@@ -17,6 +17,13 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_20
 )
 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+)
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         include


### PR DESCRIPTION
CMake has the stupid default of building with -std=gnu++20 instead of
-std=c++20 unless you explicitly ban GNU extensions.

See: https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html