### PR TITLE
Fix VS2019-build

### DIFF
--- a/cmake/conan.cmake
+++ b/cmake/conan.cmake
@@ -10,12 +10,7 @@ include(${CMAKE_BINARY_DIR}/conan.cmake)
 
 conan_cmake_run(
     REQUIRES
-        boost_asio/1.69.0@bincrafters/stable
-        boost_program_options/1.69.0@bincrafters/stable
-        boost_system/1.69.0@bincrafters/stable
-        boost_thread/1.69.0@bincrafters/stable
-        boost_random/1.69.0@bincrafters/stable
-        cmake_findboost_modular/1.69.0@bincrafters/stable
+        boost/1.73.0
         msgpack/3.2.1
         range-v3/0.10.0
         websocketpp/0.8.2
@@ -30,3 +25,20 @@ conan_cmake_run(
 )
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+
+find_package(range-v3 REQUIRED)
+target_compile_options(range-v3::range-v3
+    INTERFACE
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /Zc:preprocessor;
+            /permissive-;
+        >
+)
+
+find_package(yaml-cpp REQUIRED)
+target_compile_definitions(yaml-cpp::yaml-cpp
+    INTERFACE
+        $<$<CXX_COMPILER_ID:MSVC>:
+            _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING;
+        >
+)

--- a/core/database/include/database/in_memory_database.hpp
+++ b/core/database/include/database/in_memory_database.hpp
@@ -3,7 +3,7 @@
 #include "database.h"
 
 #include <range/v3/view/map.hpp>
-#include <range/v3/to_container.hpp>
+#include <range/v3/range/conversion.hpp>
 
 #include <unordered_map>
 

--- a/third_party/autobahn_cpp/CMakeLists.txt
+++ b/third_party/autobahn_cpp/CMakeLists.txt
@@ -27,6 +27,18 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(autobahn_cpp)
 
+if(TABETAI2_USE_CONAN)
+    find_package(msgpack REQUIRED)
+    find_package(OpenSSL REQUIRED)
+    find_package(websocketpp REQUIRED)
+    target_link_libraries(autobahn_cpp
+        INTERFACE
+            msgpack::msgpack
+            OpenSSL::OpenSSL
+            websocketpp::websocketpp
+    )
+endif()
+
 target_link_libraries(autobahn_cpp
     INTERFACE
         $<$<BOOL:${WIN32}>:ws2_32>

--- a/wamp/wamp_session/src/impl/wamp_session.cpp
+++ b/wamp/wamp_session/src/impl/wamp_session.cpp
@@ -55,7 +55,7 @@ void WampSession::run(std::function<void(wamp_session::WampSession&)> func) {
 
                 try {
                     func(*this);
-                } catch (const std::exception& e) {
+                } catch (const std::exception&) {
                     io.stop();
                     throw;
                 }

--- a/yaml_database/include/yaml_database/yaml_database.hpp
+++ b/yaml_database/include/yaml_database/yaml_database.hpp
@@ -3,7 +3,7 @@
 #include <database/database.h>
 #include <database/id_generator.h>
 
-#include <range/v3/to_container.hpp>
+#include <range/v3/range/conversion.hpp>
 #include <range/v3/view/transform.hpp>
 #include <yaml-cpp/yaml.h>
 


### PR DESCRIPTION
* Simplify conan boost dependency.
* Make sure range-v3 provides the compilation flags it requires.
* Silence deprecation warnings in yaml-cpp.
* Replace deprecated range/v3/to_container with the new ones.
* Make sure autobahn has its dependencies.
* Remove unreferenced argument to fix warning.

The deprecation warnings in yaml-cpp have been fixed in master, but
they've yet to tag a release with the fix.

range/v3/to_container is deprecated in favour of
range/v3/range/conversion.

autobahn has never correctly pulled in msgpack or websocketpp when
building with conan due to the casing differences in the names between
what they use and what conan uses. How has this ever worked? :D