### PR TITLE
Namespace CMake targets

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -18,9 +18,9 @@ set_target_properties(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        database
-        server
-        wamp_publisher
-        wamp_session
-        warning
+        tabetai::database
+        tabetai::server
+        tabetai::wamp_publisher
+        tabetai::wamp_session
+        tabetai::warning
 )

--- a/core/data_publisher/CMakeLists.txt
+++ b/core/data_publisher/CMakeLists.txt
@@ -1,6 +1,7 @@
-project(data_publisher)
+project(tabetai_data_publisher)
 
 add_library(${PROJECT_NAME} INTERFACE)
+add_library(tabetai::data_publisher ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     INTERFACE
@@ -14,10 +15,10 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     INTERFACE
-        ingredient
-        recipe
-        repository
-        util
+        tabetai::ingredient
+        tabetai::recipe
+        tabetai::repository
+        tabetai::util
 )
 
 add_subdirectory(test)

--- a/core/data_publisher/test/CMakeLists.txt
+++ b/core/data_publisher/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(test_data_publisher)
+project(test_tabetai_data_publisher)
 
 include(Catch)
 
@@ -9,10 +9,10 @@ add_executable(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        data_publisher
+        tabetai::data_publisher
         # TODO(robinlinden): Mocking a repository would be cleaner, but we
         # already get this dependency from data_publisher.
-        ingredient
+        tabetai::ingredient
         Catch2::Catch2
 )
 

--- a/core/database/CMakeLists.txt
+++ b/core/database/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(database)
+project(tabetai_database)
 
 find_package(range-v3 REQUIRED)
 
@@ -12,6 +12,7 @@ add_library(${PROJECT_NAME}
     src/impl/id_generator.cpp
     src/impl/id_generator.h
 )
+add_library(tabetai::database ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     PRIVATE

--- a/core/ingredient/CMakeLists.txt
+++ b/core/ingredient/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(ingredient)
+project(tabetai_ingredient)
 
 find_package(range-v3 REQUIRED)
 
@@ -8,6 +8,7 @@ add_library(${PROJECT_NAME}
     src/ingredient.cpp
     src/ingredient_repository.cpp
 )
+add_library(tabetai::ingredient ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     PRIVATE
@@ -28,8 +29,8 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        repository
+        tabetai::repository
     PRIVATE
-        warning
+        tabetai::warning
         range-v3::range-v3
 )

--- a/core/recipe/CMakeLists.txt
+++ b/core/recipe/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(recipe)
+project(tabetai_recipe)
 
 find_package(range-v3 REQUIRED)
 
@@ -12,6 +12,7 @@ add_library(${PROJECT_NAME}
     src/recipe_repository.cpp
     src/quantity.cpp
 )
+add_library(tabetai::recipe ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     PRIVATE
@@ -32,10 +33,10 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        repository
-        ingredient
+        tabetai::repository
+        tabetai::ingredient
     PRIVATE
-        warning
+        tabetai::warning
         range-v3::range-v3
 )
 

--- a/core/recipe/test/CMakeLists.txt
+++ b/core/recipe/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(test_recipe)
+project(test_tabetai_recipe)
 
 include(Catch)
 
@@ -9,7 +9,7 @@ add_executable(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        recipe
+        tabetai::recipe
         Catch2::Catch2
 )
 

--- a/core/repository/CMakeLists.txt
+++ b/core/repository/CMakeLists.txt
@@ -1,6 +1,7 @@
-project(repository)
+project(tabetai_repository)
 
 add_library(${PROJECT_NAME} INTERFACE)
+add_library(tabetai::repository ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     INTERFACE
@@ -14,6 +15,6 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     INTERFACE
-        database
-        util
+        tabetai::database
+        tabetai::util
 )

--- a/core/server/CMakeLists.txt
+++ b/core/server/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(server)
+project(tabetai_server)
 
 add_library(${PROJECT_NAME}
     include/server/server.h
@@ -7,6 +7,7 @@ add_library(${PROJECT_NAME}
     src/impl/server.cpp
     src/server_factory.cpp
 )
+add_library(tabetai::server ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     PRIVATE
@@ -29,10 +30,10 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        data_publisher
+        tabetai::data_publisher
     PRIVATE
-        ingredient
-        recipe
-        warning
-        yaml_database
+        tabetai::ingredient
+        tabetai::recipe
+        tabetai::warning
+        tabetai::yaml_database
 )

--- a/core/util/CMakeLists.txt
+++ b/core/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(util)
+project(tabetai_util)
 
 add_library(${PROJECT_NAME}
     include/util/observable.h
@@ -7,6 +7,7 @@ add_library(${PROJECT_NAME}
 
     src/observable.cpp
 )
+add_library(tabetai::util ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     PRIVATE
@@ -27,5 +28,5 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        warning
+        tabetai::warning
 )

--- a/wamp/wamp_data/CMakeLists.txt
+++ b/wamp/wamp_data/CMakeLists.txt
@@ -1,6 +1,7 @@
-project(wamp_data)
+project(tabetai_wamp_data)
 
 add_library(${PROJECT_NAME} INTERFACE)
+add_library(tabetai::wamp_data ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     INTERFACE

--- a/wamp/wamp_publisher/CMakeLists.txt
+++ b/wamp/wamp_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(wamp_publisher)
+project(tabetai_wamp_publisher)
 
 add_library(${PROJECT_NAME}
     include/wamp_publisher/repository_publisher_factory.h
@@ -9,6 +9,7 @@ add_library(${PROJECT_NAME}
     src/recipe_repository_publisher.cpp
     src/repository_publisher_factory.cpp
 )
+add_library(tabetai::wamp_publisher ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     PRIVATE
@@ -29,10 +30,10 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        data_publisher
-        ingredient
-        recipe
-        wamp_data
-        wamp_session
-        warning
+        tabetai::data_publisher
+        tabetai::ingredient
+        tabetai::recipe
+        tabetai::wamp_data
+        tabetai::wamp_session
+        tabetai::warning
 )

--- a/wamp/wamp_session/CMakeLists.txt
+++ b/wamp/wamp_session/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(wamp_session)
+project(tabetai_wamp_session)
 
 add_library(${PROJECT_NAME}
     include/wamp_session/wamp_session_factory.h
@@ -8,6 +8,7 @@ add_library(${PROJECT_NAME}
     src/impl/wamp_session.h
     src/wamp_session_factory.cpp
 )
+add_library(tabetai::wamp_session ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     PRIVATE
@@ -28,8 +29,8 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        wamp_data
+        tabetai::wamp_data
     PRIVATE
         autobahn_cpp
-        warning::low
+        tabetai::warning::low
 )

--- a/warning/CMakeLists.txt
+++ b/warning/CMakeLists.txt
@@ -1,5 +1,6 @@
-add_library(warning INTERFACE)
-target_compile_options(warning INTERFACE
+add_library(tabetai_warning INTERFACE)
+add_library(tabetai::warning ALIAS tabetai_warning)
+target_compile_options(tabetai_warning INTERFACE
     $<$<CXX_COMPILER_ID:Clang,GNU>:
         -Wall;
         -Wcast-align;
@@ -22,8 +23,9 @@ target_compile_options(warning INTERFACE
     >
 )
 
-add_library(warning_low INTERFACE)
-target_compile_options(warning_low INTERFACE
+add_library(tabetai_warning_low INTERFACE)
+add_library(tabetai::warning::low ALIAS tabetai_warning_low)
+target_compile_options(tabetai_warning_low INTERFACE
     $<$<CXX_COMPILER_ID:Clang,GNU>:
         -Wall;
         -Wcast-align;
@@ -41,8 +43,7 @@ target_compile_options(warning_low INTERFACE
         /WX;
     >
 )
-target_compile_definitions(warning_low
+target_compile_definitions(tabetai_warning_low
     INTERFACE
         _SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING # boost/asio
 )
-add_library(warning::low ALIAS warning_low)

--- a/yaml_database/CMakeLists.txt
+++ b/yaml_database/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(yaml_database)
+project(tabetai_yaml_database)
 
 find_package(range-v3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
@@ -11,6 +11,7 @@ add_library(${PROJECT_NAME}
     src/yaml_ingredient_database.cpp
     src/yaml_recipe_database.cpp
 )
+add_library(tabetai::yaml_database ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME}
     PRIVATE
@@ -34,8 +35,8 @@ target_link_libraries(${PROJECT_NAME}
         range-v3::range-v3
         yaml-cpp::yaml-cpp
     PRIVATE
-        database
-        ingredient
-        recipe
-        warning
+        tabetai::database
+        tabetai::ingredient
+        tabetai::recipe
+        tabetai::warning
 )


### PR DESCRIPTION
This is done to prevent conflicts with other libraries and follow cmake
convention.